### PR TITLE
Use union type aliases instead of const enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,4 @@ as returned and accepted by Wikibase APIs like wbgetentities or wbeditentity.
 ## Scope
 
 For now, the definitions in this repository are very limited.
-However, you can always augment them through [declaration merging][],
-for example:
-
-```
-namespace '@wmde/wikibase-datamodel-types' {
-	const enum DataType {
-		url = 'url',
-	}
-}
-```
-
-[declaration merging]: https://www.typescriptlang.org/docs/handbook/declaration-merging.html
+Feel free to send pull requests for other data (value) types.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,13 @@
-export const enum DataType {
-	string = 'string',
-}
+export type DataType = 'string';
 
-export const enum DataValueType {
-	string = 'string',
-}
+export type DataValueType = 'string';
 
 export interface DataValue {
 	type: DataValueType;
 	value: string;
 }
 
-export const enum SnakType {
-	value = 'value',
-	somevalue = 'somevalue',
-	novalue = 'novalue',
-}
+export type SnakType = 'value' | 'somevalue' | 'novalue';
 
 export interface Snak {
 	snaktype: SnakType;
@@ -43,11 +35,7 @@ export interface Reference {
 	'snaks-order': string[];
 }
 
-export const enum Rank {
-	preferred = 'preferred',
-	normal = 'normal',
-	deprecated = 'deprecated',
-}
+export type Rank = 'preferred' | 'normal' | 'deprecated';
 
 export interface Statement {
 	id?: string; // absent in newly created statements (fresh ID assigned server-side on save)

--- a/wikibase-datamodel-tests.ts
+++ b/wikibase-datamodel-tests.ts
@@ -2,26 +2,22 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import {
-	DataType,
-	DataValueType,
-	Rank,
-	SnakType,
 	Statement,
 	StatementMap,
 } from '.';
 
 const douglasAdamsStatement: Statement = {
 	mainsnak: {
-		snaktype: SnakType.value,
+		snaktype: 'value',
 		property: 'P373',
-		datatype: DataType.string,
+		datatype: 'string',
 		datavalue: {
-			type: DataValueType.string,
+			type: 'string',
 			value: 'Douglas Adams',
 		},
 	},
 	type: 'statement',
-	rank: Rank.normal,
+	rank: 'normal',
 };
 
 const douglasAdamsStatements: StatementMap = {


### PR DESCRIPTION
We don’t want to use const enums, for two reasons:

1. It seems to be generally discouraged to share const enums across module boundaries; they are apparently mostly intended as an internal mechanism. (I have yet to find any documentation that tells you this, but [this comment][1] seems to imply we’re supposed to understand this naturally.)

2. Babel’s TypeScript transform plugin [does not support them][2]. There is [a plugin][3] to transform const enums into non-const ones, but it seems to be intended for your own code, not for dependencies. This means that Data Bridge can’t use this module as long as it uses const enums, because they will not be inlined at compile time, but rather be sought for at run time, when they don’t exist.

With type aliases for union types, we lose the possibility for declaration merging, but it’s unclear how significant this actually was. If we (the Wikidata team) need more data (value) types, it’ll make more sense to add them upstream (here) anyways, rather than augmenting the declarations in our downstream projects.

(Side note: the augmentation syntax in the README.md was incorrect anyways – a namespace name must be an identifier, not a string literal. An ambient module would have been closer to the real syntax.)

[1]: https://github.com/microsoft/TypeScript/issues/37179#issuecomment-594070333
[2]: https://github.com/babel/babel/issues/8741
[3]: https://github.com/dosentmatter/babel-plugin-const-enum