### PR TITLE
Enable isolatedModules flag

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "module": "commonjs",
         "types": [],
         "noEmit": true,
+        "isolatedModules": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [


### PR DESCRIPTION
With this flag, TypeScript will report an error if we use features that don’t work in isolated transpilation mode (see [documentation][1]), such as const enums. (Technically, it won’t complain if you *declare* a const enum, but it will complain if you try to access it in the test file.)

[1]: https://microsoft.github.io/TypeScript-New-Handbook/reference/compiler-options/#isolatedmodules