### PR TITLE
publish automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+on:
+  release:
+    types: [ created ]
+name: Verify and Publish
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install
+        run: npm ci
+      - name: Test
+        run: npm test
+      - name: Publish
+        run: |
+          printf '//registry.npmjs.org/:_authToken=%s\n' '${{ secrets.NPM_AUTH_TOKEN }}' > ~/.npmrc
+          npm publish --access public


### PR DESCRIPTION
Publish to the registry when a release is cut, removing the human
element. Relies on a correctly configured token in NPM_AUTH_TOKEN.

Based on e.g.
https://github.com/wmde/eslint-config-wikimedia-typescript/blame/68a1663/.github/workflows/release.yml
and feedback from https://gerrit.wikimedia.org/r/572854