### PR TITLE
add package keywords for better discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,10 @@
 		"@wmde/eslint-config-wikimedia-typescript": "^0.1.1",
 		"eslint-config-wikimedia": "^0.15.3",
 		"typescript": "^3.9.3"
-	}
+	},
+	"keywords": [
+		"wikibase",
+		"wikidata",
+		"typescript"
+	]
 }


### PR DESCRIPTION
Keywords are indexed & shown on registries - they help users understand
the purpose of packages.