### PR TITLE
only publish/expose index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.2",
 	"description": "TypeScript definitions for the Wikibase data model expressed as flat JS objects",
 	"main": "",
+	"files": [
+		"index.d.ts"
+	],
 	"scripts": {
 		"test": "npm run lint && tsc",
 		"lint": "eslint index.d.ts wikibase-datamodel-tests.ts",


### PR DESCRIPTION
Ensure that files of no interest to consumers of this library are not
needlessly published.
Npm housekeeping files will automatically be kept regardless of this
setting [0].

[0]: https://docs.npmjs.com/files/package.json#files